### PR TITLE
Fix pour package_source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if (${VARIANTE_SHA} MATCHES "740444f437149a43d9f494c09ceec14f974517a6886da494619
   message(FATAL_ERROR "** ERREUR **: Vous devez modifier CMakeLists.txt pour y mettre vos logins")
 endif()
 execute_process(COMMAND echo ${VARIANTE_SHA} COMMAND tr "a-f" "A-F" COMMAND xargs printf "10 o 16 i %s 3 %% p" COMMAND dc OUTPUT_VARIABLE VARIANTE_SUJET)
-execute_process(COMMAND echo "${VARIANTE_LOGINS}" COMMAND sed "s/\;/-/g" OUTPUT_VARIABLE VARIANTE_LOGINS)
+execute_process(COMMAND printf "${VARIANTE_LOGINS}" COMMAND sed "s/;/-/g" OUTPUT_VARIABLE VARIANTE_LOGINS)
 message("Votre variante sera la variante numéro " ${VARIANTE_SUJET})
 configure_file (
   src/variante.h.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ endif(COMMAND cmake_policy)
 project(Allocphy)
 enable_testing()
 set(CMAKE_BUILD_TYPE Debug)
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -Werror")
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -Werror -std=c99")
 
 #########
 # Gestion des variantes
@@ -23,6 +23,7 @@ if (${VARIANTE_SHA} MATCHES "740444f437149a43d9f494c09ceec14f974517a6886da494619
   message(FATAL_ERROR "** ERREUR **: Vous devez modifier CMakeLists.txt pour y mettre vos logins")
 endif()
 execute_process(COMMAND echo ${VARIANTE_SHA} COMMAND tr "a-f" "A-F" COMMAND xargs printf "10 o 16 i %s 3 %% p" COMMAND dc OUTPUT_VARIABLE VARIANTE_SUJET)
+execute_process(COMMAND echo "${VARIANTE_LOGINS}" COMMAND sed "s/\;/-/g" OUTPUT_VARIABLE VARIANTE_LOGINS)
 message("Votre variante sera la variante numéro " ${VARIANTE_SUJET})
 configure_file (
   src/variante.h.in


### PR DESCRIPTION
le **;** semble pouvoir poser des problèmes lors de la **décompression** du tar.gz. En le changeant par un - juste avant de l'introduire dans le fichier variante.h on règle le problème.
Ajout de l'option -std=c99

J'ai voulu utiliser le pull request au lieu du mail car cela m'a l'air plus pratique.
Pour trouver les erreurs j'ai utilisé cette commande pour décompresser:

```
gunzip < fichier | tar -xvf -
```

En décompressant il y a des dossiers en plus qui se génèrent et cmake ne peut pas générer les Makefile.
Si vous n'avez pas eu ces problèmes vous pouvez ignorer ça, personnellement je ne voulait pas rendre quelquechose non compilable par des simples `cmake .. && make test` et j'ai trouvé cette solution.

[_Eduardo San Martin Morote_](mailto:eduardo.san-martin-morote@ensimag.fr)
